### PR TITLE
fix: handle empty Studio site list output

### DIFF
--- a/src/tools/site.ts
+++ b/src/tools/site.ts
@@ -23,12 +23,26 @@ export function registerSiteTools( server: McpServer ) {
 				};
 			}
 
-			// TODO Studio CLI should return empty array if no sites are found
 			let sites = [];
-			try {
-				sites = JSON.parse( res.stdout.trim() );
-			} catch {
-				// noop
+			const stdout = res.stdout.trim();
+			if ( stdout ) {
+				try {
+					const parsed = JSON.parse( stdout );
+					if ( ! Array.isArray( parsed ) ) {
+						throw new Error( 'expected an array' );
+					}
+					sites = parsed;
+				} catch {
+					return {
+						content: [
+							{
+								type: 'text',
+								text: `studio site list returned unexpected output:\n\n${ stdout }`,
+							},
+						],
+						isError: true,
+					};
+				}
 			}
 			const structuredContent = { sites };
 


### PR DESCRIPTION
## Summary

- Treat blank `studio site list --format=json` output as an empty sites list.
- Return a clear error when Studio returns unexpected non-array output instead of silently reporting no sites.
- Keep structured output as `{ sites }` while returning the raw array in text output.

## Verification

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `bash -n install.sh`
- [x] `bash -n uninstall.sh`

## Platform Notes

- macOS: no platform-specific behavior changed.
- Windows: no platform-specific behavior changed.

Fixes RSM-1901