### PR TITLE
fix(install): use auth json format in installers

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -873,20 +873,17 @@ Write-Host ""
 Info "$($G.Lock) Connect to WordPress.com"
 Write-Host ""
 
-$authOutput = ''
-$authStatus = Invoke-ExternalQuiet -Exe $StudioCliCmd -Arguments @('auth','status')
-$authOutput = $authStatus.Output
-$authExitCode = $authStatus.ExitCode
+$authStatus = Invoke-ExternalQuiet -Exe $StudioCliCmd -Arguments @('auth','status','--format=json')
+$authJson = $null
+try {
+    $authJson = $authStatus.Output | ConvertFrom-Json
+} catch { }
 
-# CLI output is localized, so match on two locale-independent signals instead
-# of an English phrase:
-#   1) mentions "WordPress.com" (the error path "Authentication token invalid"
-#      does not)
-#   2) contains a backtick-quoted username
-# The status command also writes localized progress to stderr, so it must run
-# through Invoke-ExternalQuiet rather than direct PowerShell invocation.
-$wpcomUser = if ($authOutput -match '`([^`]+)`') { $Matches[1] } else { '' }
-if ($authOutput -match 'WordPress\.com' -and $wpcomUser) {
+$wpcomUser = ''
+if ($authJson -and $authJson.authenticated -and $authJson.username) {
+    $wpcomUser = [string]$authJson.username
+}
+if ($wpcomUser) {
     if ($studioFound) {
         Ok "Connected as $wpcomUser (using your WordPress Studio account)."
     } else {

--- a/install.sh
+++ b/install.sh
@@ -459,15 +459,17 @@ if ! $UPDATE_MODE; then
 	echo -e "${YELLOW}🔐 Connect to WordPress.com${NC}"
 	echo ""
 
-	AUTH_OUTPUT=$("$INSTALL_DIR/bin/studio-cli" auth status 2>&1 || true)
-	# CLI output is localized (e.g. "Авторизовано через WordPress.com як \`user\`"
-	# vs. "Authenticated with WordPress.com as \`user\`"), so match on two
-	# locale-independent signals instead of an English phrase:
-	#   1) mentions "WordPress.com" (the error path "Authentication token invalid"
-	#      does not)
-	#   2) contains a backtick-quoted username
-	WPCOM_USER=$(echo "$AUTH_OUTPUT" | sed -n 's/.*`\([^`]*\)`.*/\1/p')
-	if echo "$AUTH_OUTPUT" | grep -qi 'WordPress\.com' && [ -n "$WPCOM_USER" ]; then
+	AUTH_JSON=$("$INSTALL_DIR/bin/studio-cli" auth status --format=json 2>/dev/null || true)
+	WPCOM_USER=$(AUTH_JSON="$AUTH_JSON" "$NODE_BIN" -e "
+const raw = process.env.AUTH_JSON || '';
+try {
+	const auth = JSON.parse(raw);
+	if (auth && auth.authenticated && auth.username) {
+		process.stdout.write(auth.username);
+	}
+} catch {}
+")
+	if [ -n "$WPCOM_USER" ]; then
 		if [ -d "/Applications/Studio.app" ]; then
 			echo -e "Connected as ${GREEN}${WPCOM_USER}${NC} (using your WordPress Studio account)."
 		else


### PR DESCRIPTION
## Summary

- Use `studio-cli auth status --format=json` during macOS and Windows install authentication checks.
- Read `authenticated` and `username` from JSON instead of parsing localized CLI text.
- Keep the existing login prompt behavior when no authenticated user is returned.

## Verification

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `bash -n install.sh`
- [x] `bash -n uninstall.sh`
- [x] `git diff --check`

Fixes RSM-1900