### PR TITLE
fix(install): surface npm errors when installing wp-studio

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,10 @@ if [ -n "$CURRENT_STUDIO_VERSION" ] && [ "$CURRENT_STUDIO_VERSION" = "$STUDIO_LA
 	echo -e "  ${GREEN}✓ CLI already up to date${NC}"
 else
 	echo -e "${YELLOW}Installing CLI...${NC}"
-	PATH="$INSTALL_DIR/node/bin:$PATH" "$NPM_BIN" install -g "wp-studio@$STUDIO_LATEST" --loglevel=silent 2>&1 | grep -i "error" || true
+	if ! PATH="$INSTALL_DIR/node/bin:$PATH" "$NPM_BIN" install -g "wp-studio@$STUDIO_LATEST" --loglevel=error; then
+		echo -e "  ${RED}✗ Failed to install wp-studio@$STUDIO_LATEST${NC}" >&2
+		exit 1
+	fi
 	if [ -n "$CURRENT_STUDIO_VERSION" ]; then
 		echo -e "  ${GREEN}✓ CLI updated to $STUDIO_LATEST${NC}"
 	else


### PR DESCRIPTION
# Problem      

  The CLI install step swallows npm's exit code:
                                          
  ```bash
  "$NPM_BIN" install -g "wp-studio@$STUDIO_LATEST" --loglevel=silent 2>&1 | grep -i "error" || true             
  ```                                         
                                                                                                                
  `--loglevel=silent` hides npm's output and `| grep ... || true` discards its exit code. When the install
  fails, the script still prints `✓ CLI installed` and generates a wrapper pointing at a `studio` binary that   
  was never written. Every later MCP call then fails with "studio doesn't exist," with no hint that the original
   install was the cause.                                                                                       
                  
  ## Reproduction                                                                                               
                  
  Temporarily change `STUDIO_LATEST` in `install.sh` to a version that doesn't exist on npm, then run the
  installer. 
  
  Note: helped me realize I swapped to a mirror a long time ago when there was an outage and forgot to swap it back, so thank you